### PR TITLE
enhance phpcs rules

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,16 +1,38 @@
 <?php
 
-$finder = PhpCsFixer\Finder::create()->in(['src']);
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('vendor')
+    ->in(__DIR__);
 
-return PhpCsFixer\Config::create()
+$config = PhpCsFixer\Config::create()
+    ->setUsingCache(false) // Disable creation of .php_cs.cache
     ->setRules([
         '@PSR2' => true,
+        'linebreak_after_opening_tag' => true,
         'lowercase_constants' => false,
         'method_argument_space' => false,
+        'single_quote' => true,
         'concat_space' => ['spacing' => 'one'],
+        'list_syntax' => ['syntax' => 'long'],
+        'no_extra_blank_lines' => ['extra'],
+        'ordered_imports' => [
+          'sort_algorithm' => 'length'
+        ],
+        'not_operator_with_successor_space' => true,
+        'trailing_comma_in_multiline_array' => true,
+        'single_blank_line_at_eof' => true,
+        'single_blank_line_before_namespace' => true,
         'binary_operator_spaces' => [
             'align_equals' => true,
             'align_double_arrow' => true,
         ],
+        'method_argument_space' => [
+          'ensure_fully_multiline' => true
+        ],
+        'braces' => [
+          'position_after_anonymous_constructs' => 'next',
+        ]
     ])
     ->setFinder($finder);
+
+return $config;

--- a/README.MD
+++ b/README.MD
@@ -42,6 +42,15 @@ To run the seeder file :
 
 ``php artisan db:seed --class=VoyagerDeploymentOrchestratorSeeder``
 
+### Contribuing
+
+Run phpcs linter to check for any error that may happen during PR.
+
+```composer lint```
+
+Fix errors reported by CI during Pull request.
+
+```composer fix```
 
 ### Future Tasks
 - [x] Generating Seed Files On BREAD Events.

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,9 @@
         "DrudgeRajen\\VoyagerDeploymentOrchestrator\\VoyagerDeploymentOrchestratorServiceProvider"
       ]
     }
+  },
+  "scripts": {
+    "lint": "php-cs-fixer fix --diff --dry-run",
+    "fix": "php-cs-fixer fix -vvv"
   }
 }

--- a/src/ContentManager/ContentManager.php
+++ b/src/ContentManager/ContentManager.php
@@ -127,7 +127,8 @@ class ContentManager
             unset($dataTypeArray['translations']);
         }
 
-        return $this->populateInsertStatements($stub,
+        return $this->populateInsertStatements(
+            $stub,
             $tableName,
             $dataTypeArray,
             '{{insert_statements}}'
@@ -148,12 +149,14 @@ class ContentManager
         $dataArray = $this->repackContentData($rows->toArray());
         $tableName = $rows->last()->getTable();
 
-        $stub = str_replace('{{datatype_slug_statement}}',
+        $stub = str_replace(
+            '{{datatype_slug_statement}}',
             $this->contentGenerator->getDataTypeSlugStatement($dataType),
             $stub
         );
 
-        return $this->populateInsertStatements($stub,
+        return $this->populateInsertStatements(
+            $stub,
             $tableName,
             $dataArray,
             '{{insert_statements}}'
@@ -173,12 +176,14 @@ class ContentManager
         $stub = $this->populateDeleteStatements($stub, $dataType);
 
         if ($dataType->generate_permissions) {
-            $stub = $this->replaceString('{{permission_delete_statements}}',
+            $stub = $this->replaceString(
+                '{{permission_delete_statements}}',
                 $this->contentGenerator->getPermissionStatement($dataType, 'delete'),
                 $stub
             );
         } else {
-            $stub = $this->replaceString('{{permission_delete_statements}}',
+            $stub = $this->replaceString(
+                '{{permission_delete_statements}}',
                 '',
                 $stub
             );
@@ -202,12 +207,14 @@ class ContentManager
     private function populatePermissionStatements(string $stub, DataType $dataType)
     {
         if ($dataType->generate_permissions) {
-            $stub = $this->replaceString('{{permission_insert_statements}}',
+            $stub = $this->replaceString(
+                '{{permission_insert_statements}}',
                 $this->contentGenerator->getPermissionStatement($dataType),
                 $stub
             );
         } else {
-            $stub = $this->replaceString('{{permission_insert_statements}}',
+            $stub = $this->replaceString(
+                '{{permission_insert_statements}}',
                 '',
                 $stub
             );
@@ -226,7 +233,8 @@ class ContentManager
      */
     private function populateDeleteStatements(string $stub, DataType $dataType)
     {
-        return $this->replaceString('{{delete_statements}}',
+        return $this->replaceString(
+            '{{delete_statements}}',
             $this->contentGenerator->getDeleteStatement($dataType),
             $stub
         );
@@ -242,7 +250,8 @@ class ContentManager
      */
     private function populateMenuStatements(string $stub, DataType $dataType)
     {
-        return $this->replaceString('{{menu_insert_statements}}',
+        return $this->replaceString(
+            '{{menu_insert_statements}}',
             $this->contentGenerator->getMenuInsertStatements($dataType),
             $stub
         );
@@ -259,12 +268,14 @@ class ContentManager
     private function populateTranslationStatements(string $stub, DataType $dataType)
     {
         if (! count($dataType->translations)) {
-            $stub = $this->replaceString('{{translation_insert_statements}}',
+            $stub = $this->replaceString(
+                '{{translation_insert_statements}}',
                 '',
                 $stub
             );
 
-            $stub = $this->replaceString('{{datatype_slug_statements}}',
+            $stub = $this->replaceString(
+                '{{datatype_slug_statements}}',
                 '',
                 $stub
             );
@@ -275,12 +286,14 @@ class ContentManager
         $tableName    = $dataType->translations->last()->getTable();
         $translations = $this->repackContentData($dataType->translations->toArray());
 
-        $stub = $this->replaceString('{{datatype_slug_statements}}',
+        $stub = $this->replaceString(
+            '{{datatype_slug_statements}}',
             $this->contentGenerator->getDataTypeSlugStatement($dataType),
             $stub
         );
 
-        $stub = $this->populateInsertStatements($stub,
+        $stub = $this->populateInsertStatements(
+            $stub,
             $tableName,
             $translations,
             '{{translation_insert_statements}}'

--- a/src/ContentManager/FileGenerator.php
+++ b/src/ContentManager/FileGenerator.php
@@ -96,7 +96,8 @@ class FileGenerator
 
         $seederFile = $this->fileSystem->getSeederFile($seederClassName, $seedFolderPath);
 
-        $seedContent = $this->contentManager->populateContentToStubFile($seederClassName,
+        $seedContent = $this->contentManager->populateContentToStubFile(
+            $seederClassName,
             $stub,
             $dataType,
             self::ROW_SEEDER_SUFFIX
@@ -156,11 +157,13 @@ class FileGenerator
      */
     public function deleteSeedFiles(DataType $dataType)
     {
-        $dataTypSeederClass = $this->fileSystem->generateSeederClassName($dataType->slug,
+        $dataTypSeederClass = $this->fileSystem->generateSeederClassName(
+            $dataType->slug,
             self::TYPE_SEEDER_SUFFIX
         );
 
-        $dataRowSeederClass = $this->fileSystem->generateSeederClassName($dataType->slug,
+        $dataRowSeederClass = $this->fileSystem->generateSeederClassName(
+            $dataType->slug,
             self::ROW_SEEDER_SUFFIX
         );
 
@@ -193,7 +196,8 @@ class FileGenerator
 
         $seederFile = $this->fileSystem->getSeederFile($seederClassName, $seedFolderPath);
 
-        $seedContent = $this->contentManager->populateContentToStubFile($seederClassName,
+        $seedContent = $this->contentManager->populateContentToStubFile(
+            $seederClassName,
             $stub,
             $dataType,
             self::DELETED_SEEDER_SUFFIX

--- a/src/VoyagerDeploymentOrchestrator.php
+++ b/src/VoyagerDeploymentOrchestrator.php
@@ -56,8 +56,10 @@ class VoyagerDeploymentOrchestrator
      */
     public function handle(BreadChanged $breadChanged)
     {
-        if (! in_array($breadChanged->dataType->name,
-            config('voyager-deployment-orchestrator.tables'))
+        if (! in_array(
+            $breadChanged->dataType->name,
+            config('voyager-deployment-orchestrator.tables')
+        )
         ) {
             return;
         }


### PR DESCRIPTION
This PR has following changes.

- updated phpcs rules to cover the existing code conventions
- update phpcs rule to split multiple arguments into separate line as per PSR2 which was not taking an effect.
- fix StyleCI issue by adding long syntax for `list_syntax`
- disable generation of `.php_cs.cache` file each time we run `php-cs-fixer --diff --dry-run`

Added Two new composer scripts.

```composer lint```

Dry runs php-cs-fixer and shows file that will be changed when we actually run `composer fix`

```composer fix```

It will actually fix files that are reported by `php-cs-fixer` during dry run.
