### PR TITLE
Clear menu cache

### DIFF
--- a/src/OrchestratorHandlers/BreadDeletedHandler.php
+++ b/src/OrchestratorHandlers/BreadDeletedHandler.php
@@ -2,6 +2,7 @@
 
 namespace DrudgeRajen\VoyagerDeploymentOrchestrator\OrchestratorHandlers;
 
+use Illuminate\Support\Facades\Artisan;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Events\BreadChanged;
 use DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManager\FileGenerator;
@@ -47,6 +48,9 @@ class BreadDeletedHandler
 
         // Finally, We can delete seed files.
         $this->fileGenerator->deleteSeedFiles($dataType);
+
+        // Since, voyager cache the menu, after seed deletion we clear admin menu cache as well.
+        Artisan::call('cache:forget', ['key' => 'voyager_menu_admin']);
 
         // After deleting seeds file, we create new seed file in order to rollback
         // the seeded data.

--- a/src/OrchestratorHandlers/BreadDeletedHandler.php
+++ b/src/OrchestratorHandlers/BreadDeletedHandler.php
@@ -2,9 +2,9 @@
 
 namespace DrudgeRajen\VoyagerDeploymentOrchestrator\OrchestratorHandlers;
 
-use Illuminate\Support\Facades\Artisan;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Events\BreadChanged;
+use Illuminate\Support\Facades\Artisan;
 use DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManager\FileGenerator;
 
 class BreadDeletedHandler

--- a/src/stubs/delete_seed.stub
+++ b/src/stubs/delete_seed.stub
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Database\Seeder;
 use TCG\Voyager\Models\DataType;
 use TCG\Voyager\Facades\Voyager;
@@ -25,6 +26,9 @@ class {{class}} extends Seeder
         {{permission_delete_statements}}
 
         {{menu_delete_statements}}
+
+        // Since, voyager cache the menu, after seed deletion we clear admin menu cache as well.
+        Artisan::call('cache:forget', ['key' => 'voyager_menu_admin']);
        } catch(Exception $e) {
          throw new Exception('Exception occur ' . $e);
 


### PR DESCRIPTION
Voyager Caches the menu while displaying menu builder.  In case the BREAD seeder deleted, we also need to clear the menu cache so that we don't see the cached menu in the sidebar.