### PR TITLE
VDO Generate Seeder Command

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -39,9 +39,24 @@ autoload composer so that laravel knows about new seeders.
 Voyager Fires Events on Insert, Update, and Delete of BREAD.
 This package listens for those events and creates respective seeder files.
 
-#### To run the seeder file:
+### To run the seeder file:
 
 ```php artisan db:seed --class=VoyagerDeploymentOrchestratorSeeder```
+
+### Generating seeder files for table
+VDO also provides an artisan command to generate the seed file for table.
+In order to generate the seeder file for tables
+
+```php artisan vdo:generate table-name1```
+
+It also supports the generation for multiple tables.
+``` php artisan vdo:generate table-name1,table-name2,table-name3```
+
+VDO seed generator command will keep the generated seed files inside `/database/seeds/breads` with prefix `TableSeeder`
+
+***Note:*** VDO seed generator will not add the seeder file in `VoyagerDeploymentOrchestratorSeeder.php` class automatically, because
+this class in only used for BREAD seeders not the tables seeder. If you want to run all the vdo generated seeder at once,
+please add those in `DatabaseSeeder.php` class.
 
 ### Contributing
 
@@ -54,6 +69,4 @@ Fix errors reported by CI during Pull request.
 ```composer fix```
 
 ### Future Tasks
-- [x] Generating Seed Files On BREAD Events.
-
 - [ ] Writing Tests

--- a/README.MD
+++ b/README.MD
@@ -43,13 +43,14 @@ This package listens for those events and creates respective seeder files.
 
 ```php artisan db:seed --class=VoyagerDeploymentOrchestratorSeeder```
 
-### Generating seeder files for table
+### Generating seeder files for tables
 VDO also provides an artisan command to generate the seed file for table.
-In order to generate the seeder file for tables
+In order to generate the seeder file for tables,
 
 ```php artisan vdo:generate table-name1```
 
 It also supports the generation for multiple tables.
+
 ``` php artisan vdo:generate table-name1,table-name2,table-name3```
 
 VDO seed generator command will keep the generated seed files inside `/database/seeds/breads` with prefix `TableSeeder`

--- a/src/Commands/VDOSeed.php
+++ b/src/Commands/VDOSeed.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace DrudgeRajen\VoyagerDeploymentOrchestrator\Commands;
+
+use DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManger\FileSystem;
+use Illuminate\Console\Command;
+
+class VDOSeed extends Command
+{
+    protected $suffix = 'TableSeeder';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'vdo:generate {tables}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate Seed files for voyager tables, except for BREAD.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(FileSystem $fileSystem)
+    {
+        parent::__construct();
+        $this->fileSystem = $fileSystem;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $tables = explode(",", $this->argument('tables'));
+
+        foreach($tables as $table) {
+            $this->fileSystem->generateSeederClassName($table, $this->suffix);
+        }
+    }
+
+}

--- a/src/Commands/VDOSeed.php
+++ b/src/Commands/VDOSeed.php
@@ -3,8 +3,8 @@
 namespace DrudgeRajen\VoyagerDeploymentOrchestrator\Commands;
 
 use Exception;
-use DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManager\FileGenerator;
 use Illuminate\Console\Command;
+use DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManager\FileGenerator;
 
 class VDOSeed extends Command
 {
@@ -46,7 +46,7 @@ class VDOSeed extends Command
      */
     public function handle()
     {
-        $tables = explode(",", $this->argument('tables'));
+        $tables = explode(',', $this->argument('tables'));
 
         try {
             foreach ($tables as $table) {
@@ -55,7 +55,7 @@ class VDOSeed extends Command
                     $this->fileGenerator->generateVDOSeedFile($table, $this->suffix)
                 );
             }
-        } catch(Exception $exception) {
+        } catch (Exception $exception) {
             $this->printResult($table, false);
         }
     }
@@ -75,5 +75,4 @@ class VDOSeed extends Command
 
         $this->error("Could not create seed file from table {$table}");
     }
-
 }

--- a/src/Commands/VDOSeed.php
+++ b/src/Commands/VDOSeed.php
@@ -61,7 +61,7 @@ class VDOSeed extends Command
     }
 
     /**
-     * Print Result
+     * Print Result.
      *
      * @param string $table
      * @param bool $isSuccess
@@ -70,6 +70,7 @@ class VDOSeed extends Command
     {
         if ($isSuccess) {
             $this->info("Created a seed file from table {$table}");
+
             return;
         }
 

--- a/src/ContentManager/ContentManager.php
+++ b/src/ContentManager/ContentManager.php
@@ -59,7 +59,6 @@ class ContentManager
     /**
      * Populate Content To Stub File.
      *
-     * @param string $className
      * @param string $stub
      * @param DataType $dataType
      * @param string $suffix
@@ -67,13 +66,10 @@ class ContentManager
      * @return mixed|string
      */
     public function populateContentToStubFile(
-        string $className,
         string $stub,
         DataType $dataType,
         string $suffix
     ) {
-        $stub = $this->replaceString('{{class}}', $className, $stub);
-
         switch ($suffix) {
             case FileGenerator::TYPE_SEEDER_SUFFIX:
                 $stub = $this->populateDataTypeSeederContent($stub, $dataType);
@@ -334,8 +330,13 @@ class ContentManager
      *
      * @return mixed
      */
-    private function replaceString($search, $replace, $stub)
+    public function replaceString($search, $replace, $stub)
     {
         return str_replace($search, $replace, $stub);
+    }
+
+    public function populateTableContentToSeeder(string $stub, string $tableName, array $data)
+    {
+        return $this->populateInsertStatements($stub, $tableName, $data, '{{insert_statements}}');
     }
 }

--- a/src/ContentManager/FileGenerator.php
+++ b/src/ContentManager/FileGenerator.php
@@ -3,9 +3,9 @@
 namespace DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManager;
 
 use Exception;
-use Illuminate\Database\DatabaseManager;
 use TCG\Voyager\Models\DataType;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\DatabaseManager;
 use DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManger\FileSystem;
 
 class FileGenerator
@@ -246,7 +246,7 @@ class FileGenerator
      */
     public function generateVDOSeedFile(string $tableName, string $suffix) : bool
     {
-        if (!Schema::hasTable($tableName)) {
+        if (! Schema::hasTable($tableName)) {
             throw new Exception(sprintf('%s table does\'nt exist.'));
         }
 
@@ -279,12 +279,12 @@ class FileGenerator
      */
     public function repackSeedData($data) : array
     {
-        if (!is_array($data)) {
+        if (! is_array($data)) {
             $data = $data->toArray();
         }
 
         $dataArray = [];
-        if (!empty($data)) {
+        if (! empty($data)) {
             foreach ($data as $row) {
                 $rowArray = [];
                 foreach ($row as $columnName => $columnValue) {

--- a/src/ContentManager/FileGenerator.php
+++ b/src/ContentManager/FileGenerator.php
@@ -271,7 +271,7 @@ class FileGenerator
     }
 
     /**
-     * Repacks data read from the database
+     * Repacks data read from the database.
      *
      * @param  array|object $data
      *

--- a/src/ContentManager/FileSystem.php
+++ b/src/ContentManager/FileSystem.php
@@ -3,20 +3,25 @@
 namespace DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManger;
 
 use Illuminate\Filesystem\Filesystem as LaravelFileSystem;
+use Illuminate\Support\Composer;
 
 class FileSystem
 {
     /** @var LaravelFileSystem */
     private $filesystem;
 
+    /** @var Composer */
+    private $composer;
+
     /**
      * Create the event listener.
      *
      * @param LaravelFileSystem $filesystem
      */
-    public function __construct(LaravelFileSystem $filesystem)
+    public function __construct(LaravelFileSystem $filesystem, Composer $composer)
     {
         $this->filesystem = $filesystem;
+        $this->composer   = $composer;
     }
 
     /**
@@ -96,11 +101,18 @@ class FileSystem
      * @param string $seederFile
      * @param string $seederContents
      *
-     * @return int
+     * @return bool
      */
-    public function addContentToSeederFile(string $seederFile, string $seederContents) : int
+    public function addContentToSeederFile(string $seederFile, string $seederContents) : bool
     {
-        return $this->filesystem->put($seederFile, $seederContents);
+        if (!$this->filesystem->put($seederFile, $seederContents))
+        {
+            return false;
+        }
+
+        $this->composer->dumpAutoloads();
+
+        return true;
     }
 
     /**

--- a/src/ContentManager/FileSystem.php
+++ b/src/ContentManager/FileSystem.php
@@ -2,8 +2,8 @@
 
 namespace DrudgeRajen\VoyagerDeploymentOrchestrator\ContentManger;
 
-use Illuminate\Filesystem\Filesystem as LaravelFileSystem;
 use Illuminate\Support\Composer;
+use Illuminate\Filesystem\Filesystem as LaravelFileSystem;
 
 class FileSystem
 {
@@ -105,8 +105,7 @@ class FileSystem
      */
     public function addContentToSeederFile(string $seederFile, string $seederContents) : bool
     {
-        if (!$this->filesystem->put($seederFile, $seederContents))
-        {
+        if (! $this->filesystem->put($seederFile, $seederContents)) {
             return false;
         }
 

--- a/src/VoyagerDeploymentOrchestrator.php
+++ b/src/VoyagerDeploymentOrchestrator.php
@@ -3,7 +3,6 @@
 namespace DrudgeRajen\VoyagerDeploymentOrchestrator;
 
 use Exception;
-use Illuminate\Support\Composer;
 use TCG\Voyager\Events\BreadChanged;
 use Illuminate\Foundation\Application;
 use DrudgeRajen\VoyagerDeploymentOrchestrator\OrchestratorHandlers\BreadAddedHandler;
@@ -29,9 +28,6 @@ class VoyagerDeploymentOrchestrator
         self::BREAD_DELETED => BreadDeletedHandler::class,
     ];
 
-    /** @var Composer */
-    private $composer;
-
     /** @var Application */
     private $app;
 
@@ -41,9 +37,8 @@ class VoyagerDeploymentOrchestrator
      * @param Composer $composer
      * @param Application $application
      */
-    public function __construct(Composer $composer, Application $application)
+    public function __construct(Application $application)
     {
-        $this->composer = $composer;
         $this->app      = $application;
     }
 
@@ -70,8 +65,7 @@ class VoyagerDeploymentOrchestrator
             if ($handler) {
                 $handler->handle($breadChanged);
             }
-            // Run composer dump-auto
-            $this->composer->dumpAutoloads();
+
         } catch (Exception $e) {
             throw new OrchestratorHandlerNotFoundException($e->getMessage());
         }

--- a/src/VoyagerDeploymentOrchestrator.php
+++ b/src/VoyagerDeploymentOrchestrator.php
@@ -65,7 +65,6 @@ class VoyagerDeploymentOrchestrator
             if ($handler) {
                 $handler->handle($breadChanged);
             }
-
         } catch (Exception $e) {
             throw new OrchestratorHandlerNotFoundException($e->getMessage());
         }

--- a/src/VoyagerDeploymentOrchestratorServiceProvider.php
+++ b/src/VoyagerDeploymentOrchestratorServiceProvider.php
@@ -23,6 +23,8 @@ class VoyagerDeploymentOrchestratorServiceProvider extends ServiceProvider
         foreach ($publishable as $group => $paths) {
             $this->publishes($paths, $group);
         }
+
+        $this->commands(Commands\VDOSeed::class);
     }
 
     public function register()

--- a/src/stubs/seed.stub
+++ b/src/stubs/seed.stub
@@ -8,6 +8,8 @@ class {{class}} extends Seeder
      * Auto generated seed file
      *
      * @return void
+     *
+     * @throws Exception
      */
     public function run()
     {

--- a/src/stubs/seed.stub
+++ b/src/stubs/seed.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class {{class}} extends Seeder
+{
+    /**
+     * Auto generated seed file
+     *
+     * @return void
+     */
+    public function run()
+    {
+     try {
+        \DB::beginTransaction();
+
+        \DB::table('{{table}}')->delete();
+
+        {{insert_statements}}
+       } catch(Exception $e) {
+         throw new Exception('Exception occur ' . $e);
+
+         \DB::rollBack();
+       }
+
+       \DB::commit();
+    }
+}


### PR DESCRIPTION
Fixes #17 

VDO only supports the generation of BREAD Seeders. There is no option to generate the seeder file for other tables, which can be useful if we want to share the same data as well. 

This feature will provide a command which will generate a seed file for the tables provided as a command argument. 

`php artisan vdo:generate table-name`

And for multiple Tables
`php artisan vdo:generate table-name1,table-name2`

It will generate the seeder file at `/database/seeds/breads/TableNameTableSeeder.php`