### PR TITLE
Feature - Allow package installation in Voyager forks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,9 @@
   ],
   "type": "library",
   "license": "MIT",
-  "require": {
-    "tcg/voyager": "^1.1|^1.2|^1.3"
-  },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.9@dev"
+    "friendsofphp/php-cs-fixer": "^2.9@dev",
+    "tcg/voyager": "^1.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Having Voyager as dependency prevents the installation of this package in Voyager forks.
Moving it to dev solves the problem.

Also `^1.1` is equivalent to `>=1.1 <2.0` so it already includes all `1.x` versions.